### PR TITLE
Enable container publication to GitHub Container Registry.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,10 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             TAGS="${TAGS},${IMAGE_NAME}:sha-${GITHUB_SHA::8}"
           fi
+          for i in ${TAGS//,/ }
+          do
+            TAGS="${TAGS},ghcr.io/${i}"
+          done
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=source_version::$(./bump_version.sh show)
           echo ::set-output name=tags::${TAGS}
@@ -275,9 +279,10 @@ jobs:
   build-push-all:
     # Builds the final set of images for each of the platforms listed in
     # PLATFORMS environment variable.  These images are tagged with the Docker
-    # tags calculated in the "prepare" job and pushed to DockerHub.  The
-    # contents of README.md is pushed as the image's description.  This job is
-    # skipped when the triggering event is a pull request.
+    # tags calculated in the "prepare" job and pushed to DockerHub and the
+    # GitHub Container Registry.  The contents of README.md is pushed as the
+    # image's description to DockerHub.  This job is skipped when the triggering
+    # event is a pull request.
     name: "Build and push all platforms"
     runs-on: ubuntu-latest
     needs: [lint, prepare, test]
@@ -288,6 +293,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up QEMU
@@ -305,7 +316,7 @@ jobs:
             ${{ env.BASE_CACHE_KEY }}
       - name: Create cross-platform support Dockerfile-x
         run: ./buildx-dockerfile.sh
-      - name: Build and push platform images to Docker Hub
+      - name: Build and push platform images to registries
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,7 +280,7 @@ jobs:
     # Builds the final set of images for each of the platforms listed in
     # PLATFORMS environment variable.  These images are tagged with the Docker
     # tags calculated in the "prepare" job and pushed to DockerHub and the
-    # GitHub Container Registry.  The contents of README.md is pushed as the
+    # GitHub Container Registry.  The contents of README.md are pushed as the
     # image's description to DockerHub.  This job is skipped when the triggering
     # event is a pull request.
     name: "Build and push all platforms"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
Adds the ability for the images generated in the actions workflows to be pushed to the [Github Container Registry](https://docs.github.com/en/packages/guides/about-github-container-registry).


Images are now pushed to both registries.

## 💭 Motivation and Context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

DockerHub is increasingly hostile towards open projects and the teams that support them.
* team size limits
* image pull limits
* image retention limits

This is a hedge against DockerHub spontaneously disabling support for all free projects, and a stepping stone towards adding [ECR](https://aws.amazon.com/ecr/) support.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally and in CI.  And in a personal project. 

A package has already been generated and published to registries as a result of this branch: 
* https://github.com/orgs/cisagov/packages/container/package/example
* https://hub.docker.com/r/cisagov/example

All cisagov packages in a single location:
* https://github.com/orgs/cisagov/packages

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->
![kiwi](https://user-images.githubusercontent.com/3229435/112548853-44dd6100-8d93-11eb-92eb-f2f55a691ca4.gif)

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [x] All new and existing tests pass.
