### PR TITLE
Add the tag.sh Script

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+version=$(./bump_version.sh show)
+
+git tag "v$version" && git push --tags


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `tag.sh` script from [cisagov/skeleton-python-library](https://github.com/cisagov/skeleton-python-library) to this repository.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since Docker projects will build and push images to Docker Hub on tag pushes (through the GitHub Actions workflow), we should have a consistent manner of triggering this action. We use the `tag.sh` script in Python projects for a similar purpose so I thought it fitting to copy that script to this project type. Additionally this script has been used by older Docker projects that are not skeletonized for the same purpose (see [cisagov/orchestrator](https://github.com/cisagov/orchestrator), [cisagov/cyhy-mailer](https://github.com/cisagov/cyhy-mailer) and others).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I used this script to tag and push versions of [cisagov/vdp-scanner-docker](https://github.com/cisagov/vdp-scanner-docker) to get correct image pushes to Docker Hub.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
