### PR TITLE
Add a section to the README for ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ Hub for a list of all the supported tags.
 |-------------|----------------|
 | `/var/log`  |  Log storage   |
 
+## Ports ##
+
+There are no ports exposed by this container.
+
+<!-- The following ports are exposed by this container: -->
+
+<!-- | Port | Purpose        | -->
+<!-- |------|----------------| -->
+<!-- | 3333 | Admin web server | -->
+<!-- | 8080 | Phishing web server | -->
+
+<!-- The sample [Docker composition](docker-compose.yml) publishes the -->
+<!-- exposed ports at 3333 and 3380, respectively. -->
+
 ## Environment variables ##
 
 ### Required ###

--- a/README.md
+++ b/README.md
@@ -157,17 +157,14 @@ Hub for a list of all the supported tags.
 
 ## Ports ##
 
-There are no ports exposed by this container.
+The following ports are exposed by this container:
 
-<!-- The following ports are exposed by this container: -->
+| Port | Purpose        |
+|------|----------------|
+| 8080 | Example only; nothing is actually listening on the port |
 
-<!-- | Port | Purpose        | -->
-<!-- |------|----------------| -->
-<!-- | 3333 | Admin web server | -->
-<!-- | 8080 | Phishing web server | -->
-
-<!-- The sample [Docker composition](docker-compose.yml) publishes the -->
-<!-- exposed ports at 3333 and 3380, respectively. -->
+The sample [Docker composition](docker-compose.yml) publishes the
+exposed port at 8080.
 
 ## Environment variables ##
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a section to `README.md` for ports exposed by the container.

## 💭 Motivation and context ##

@dav3r noticed in cisagov/postfix-docker#25 that such a section was missing from the skeleton.

## 🧪 Testing ##

I viewed the rendered Markdown and verified that it looked _good_.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
