### PR TITLE
Update the README to reference the latest version of the Docker container

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -7,6 +7,7 @@ set -o errexit
 set -o pipefail
 
 VERSION_FILE=src/version.txt
+README_FILE=README.md
 
 HELP_INFORMATION="bump_version.sh (show|major|minor|patch|prerelease|build|finalize)"
 
@@ -23,8 +24,10 @@ else
       tmp_file=/tmp/version.$$
       sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
       mv $tmp_file $VERSION_FILE
-      git add $VERSION_FILE
-      git commit -m"Bumping version from $old_version to $new_version"
+      sed "s/$old_version/$new_version/" $README_FILE > $tmp_file
+      mv $tmp_file $README_FILE
+      git add $VERSION_FILE $README_FILE
+      git commit -m"Bump version from $old_version to $new_version"
       git push
       ;;
     finalize)
@@ -33,8 +36,10 @@ else
       tmp_file=/tmp/version.$$
       sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
       mv $tmp_file $VERSION_FILE
-      git add $VERSION_FILE
-      git commit -m"Bumping version from $old_version to $new_version"
+      sed "s/$old_version/$new_version/" $README_FILE > $tmp_file
+      mv $tmp_file $README_FILE
+      git add $VERSION_FILE $README_FILE
+      git commit -m"Bump version from $old_version to $new_version"
       git push
       ;;
     show)


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Updates `README.md` to reference the latest version of the Docker container
* Corrects `git commit` comments to use the imperative mood

## 💭 Motivation and context ##

The `README.md` change was discussed among @cisagov/team-ois [here](https://github.com/cisagov/gatherer/pull/60#pullrequestreview-683086244).

## 🧪 Testing ##

I ran `bump_version.sh` with these changes locally and verified that it behaved as expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
