### PR TITLE
Build Docker images for various platforms in a matrix strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,6 @@ env:
   CURL_CACHE_DIR: ~/.cache/curl
   IMAGE_NAME: cisagov/example
   PIP_CACHE_DIR: ~/.cache/pip
-  PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
-  linux/arm64,linux/ppc64le,linux/s390x"
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 
@@ -347,15 +345,24 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   build-push-all:
-    # Builds the final set of images for each of the platforms listed in
-    # PLATFORMS environment variable.  These images are tagged with the Docker
-    # tags calculated in the "prepare" job and pushed to Docker Hub and the
-    # GitHub Container Registry.  The contents of README.md are pushed as the
+    # Builds the final set of images for each of the platforms listed
+    # below.  These images are tagged with the Docker tags calculated
+    # in the "prepare" job and pushed to Docker Hub and the GitHub
+    # Container Registry.  The contents of README.md are pushed as the
     # image's description to Docker Hub.  This job is skipped when the
     # triggering event is a pull request.
     name: "Build and push all platforms"
     runs-on: ubuntu-latest
     needs: [lint, prepare, test]
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
     if: github.event_name != 'pull_request'
     steps:
       - name: Login to Docker Hub
@@ -396,7 +403,7 @@ jobs:
           cache-to: type=local,dest=${{ env.BUILDX_CACHE_DIR }}
           context: .
           file: ./Dockerfile-x
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ needs.prepare.outputs.tags }}
           # For a list of pre-defined annotation keys and value types see:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `build.yml` GitHub Actions workflow to build the Docker images for the various supported platforms in a matrix strategy.  The idea for this change was motivated by a conversation between @mcdonnnj and me.

**N.B.:**  This pull request is somewhat of a breaking change, as the matrix strategy breaks the previous single monolithic multi-platform build into a bundle of individual single-platform builds.

**N.B.:**  I have done away with the `PLATFORMS` environment variable and explicitly listed the available platforms in the GitHub Actions workflow yml file.  This is because I didn't see a way to easily convert a comma-delimited list of platforms stored in an environment variable into a YML list inside the workflow.  If others are able to figure that out, and we think there is benefit in having the platforms stored in an environment variable, then I'm not opposed to changing it back.


## 💭 Motivation and context ##

This change makes it easier to temporarily drop support for a failing platform that we cannot fix, as we are currently experiencing with #64.

## 🧪 Testing ##

All `pre-commit` hooks and GitHub Actions pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
