### PR TITLE
Update code to use the "docker compose" syntax vice "docker-compose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run cisagov/example:0.0.1
             source: <your_log_dir>
             target: /var/log
         environment:
-          - ECHO_MESSAGE="Hello from docker-compose"
+          - ECHO_MESSAGE="Hello from docker compose"
         ports:
           - target: 8080
             published: 8080
@@ -53,7 +53,7 @@ docker run cisagov/example:0.0.1
 1. Start the container and detach:
 
     ```console
-    docker-compose up --detach
+    docker compose up --detach
     ```
 
 ## Using secrets with your container ##
@@ -88,7 +88,7 @@ environment variables.  See the
             source: <your_log_dir>
             target: /var/log
         environment:
-          - ECHO_MESSAGE="Hello from docker-compose"
+          - ECHO_MESSAGE="Hello from docker compose"
         ports:
           - target: 8080
             published: 8080
@@ -105,13 +105,13 @@ environment variables.  See the
 1. Pull the new image from Docker Hub:
 
     ```console
-    docker-compose pull
+    docker compose pull
     ```
 
 1. Recreate the running container by following the [previous instructions](#running-with-docker-compose):
 
     ```console
-    docker-compose up --detach
+    docker compose up --detach
     ```
 
 ### Docker ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 version: "3.7"
 
-# This docker-compose file is used to build and test the container
+# This docker compose file is used to build and test the container
 
 secrets:
   quote_txt:
@@ -19,7 +19,7 @@ services:
     init: true
     restart: "no"
     environment:
-      - ECHO_MESSAGE=Hello World from docker-compose!
+      - ECHO_MESSAGE=Hello World from docker compose!
     ports:
       - target: 8080
         published: 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 version: "3.7"
 
-# This docker compose file is used to build and test the container
+# This Docker composition file is used to build and test the container
 
 secrets:
   quote_txt:

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -9,7 +9,7 @@ import time
 import pytest
 
 ENV_VAR = "ECHO_MESSAGE"
-ENV_VAR_VAL = "Hello World from docker-compose!"
+ENV_VAR_VAL = "Hello World from docker compose!"
 READY_MESSAGE = "This is a debug message"
 SECRET_QUOTE = (
     "There are no secrets better kept than the secrets everybody guesses."  # nosec


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the code to use the `docker compose` syntax instead of the `docker-compose` syntax.

## 💭 Motivation and context ##

The `docker compose` syntax is the preferred (and only correct) syntax after the changes in cisagov/ansible-role-docker#60.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] All new and existing tests pass.