### PR TITLE
Remove the tag.sh script

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -o nounset
-set -o errexit
-set -o pipefail
-
-version=$(./bump_version.sh show)
-
-git tag "v$version" && git push --tags


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the `tag.sh` script.

## 💭 Motivation and context ##

Tags should instead be created indirectly via prereleases and releases, so there is some documentation associated with the version.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.