### PR TITLE
Correctly indent multi-line double-quoted string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
   IMAGE_NAME: cisagov/example
   PIP_CACHE_DIR: ~/.cache/pip
   PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
-  linux/arm64,linux/ppc64le,linux/s390x"
+    linux/arm64,linux/ppc64le,linux/s390x"
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request corrects the indentation of a multi-line double-quoted string in the GitHub Actions `build` workflow.

## 💭 Motivation and context ##

GitHub Actions' sanity checks became more stringent in the last few hours, and this incorrect indentation is now causing builds for all descendants of this skeleton repository ti immediately fail in GitHub Actions.

## 🧪 Testing ##

All automated tests now pass.  There were not passing a few hours ago, without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.