### PR TITLE
Specify the default group to run under in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN wget --output-document sourcecode.tgz \
 # Prepare to run
 ###
 ENV ECHO_MESSAGE="Hello World from Dockerfile"
-USER ${CISA_USER}
+USER ${CISA_USER}:${CISA_GROUP}
 EXPOSE 8080/TCP
 VOLUME ["/var/log"]
 ENTRYPOINT ["example"]


### PR DESCRIPTION
## 🗣 Description ##

This pull request specifies the default group to run under in the `Dockerfile`.

## 💭 Motivation and context ##

Doesn't hurt.  May as well.

## 🧪 Testing ##

All automated tests pass.  I have been doing this in [cisagov/gatherer](https://github.com/cisagov/gatherer) for years.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.