### PR TITLE
Specify pip3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN apk --no-cache --quiet add ${DEPS}
 ###
 # Make sure pip, setuptools, and wheel are the latest versions
 #
-# Note that we use pip --no-cache-dir to avoid writing to a local
+# Note that we use pip3 --no-cache-dir to avoid writing to a local
 # cache.  This results in a smaller final image, at the cost of
 # slightly longer install times.
 ###
@@ -73,14 +73,14 @@ WORKDIR ${CISA_HOME}
 ###
 # Install Python dependencies
 #
-# Note that we use pip --no-cache-dir to avoid writing to a local
+# Note that we use pip3 --no-cache-dir to avoid writing to a local
 # cache.  This results in a smaller final image, at the cost of
 # slightly longer install times.
 ###
 RUN wget --output-document sourcecode.tgz \
     https://github.com/cisagov/skeleton-python-library/archive/v${VERSION}.tar.gz \
     && tar --extract --gzip --file sourcecode.tgz --strip-components=1 \
-    && pip install --no-cache-dir --requirement requirements.txt \
+    && pip3 install --no-cache-dir --requirement requirements.txt \
     && ln -snf /run/secrets/quote.txt src/example/data/secret.txt \
     && rm sourcecode.tgz
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `Dockerfile` to specify the use of `pip3`.

## 💭 Motivation and context ##

In this case it doesn't matter because we are starting from a Python3-specific base container, but other projects that use this skeleton may not be.  Specifying `pip3` ensures that the Python2 version of `pip` is not called by mistake.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.