### PR TITLE
Add package write permission to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,6 +345,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, prepare, test]
     if: github.event_name != 'pull_request'
+    # When Dependabot creates a PR it requires this permission in
+    # order to push Docker images to ghcr.io.
+    permissions:
+      packages: write
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
## 🗣 Description ##

This pull requests adds the `packages: write` permission for the `build-push-all` portion of the workflow.

## 💭 Motivation and context ##

When Dependabot creates a PR this permission is required in order to push Docker images to `ghcr.io`.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.