### PR TITLE
Switch packages used to test the configuration

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 --requirement requirements.txt
 pre-commit
 pytest
-pytest-dockerc
+python-on-whales

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,16 +4,25 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 """
 # Third-Party Libraries
 import pytest
+from python_on_whales import docker
 
 MAIN_SERVICE_NAME = "example"
 VERSION_SERVICE_NAME = f"{MAIN_SERVICE_NAME}-version"
 
 
 @pytest.fixture(scope="session")
+def dockerc():
+    """Start up the Docker composition."""
+    docker.compose.up(detach=True)
+    yield docker
+    docker.compose.down()
+
+
+@pytest.fixture(scope="session")
 def main_container(dockerc):
     """Return the main container from the Docker composition."""
     # find the container by name even if it is stopped already
-    return dockerc.containers(service_names=[MAIN_SERVICE_NAME], stopped=True)[0]
+    return dockerc.compose.ps(services=[MAIN_SERVICE_NAME], all=True)[0]
 
 
 @pytest.fixture(scope="session")
@@ -23,7 +32,7 @@ def version_container(dockerc):
     The version container should just output the version of its underlying contents.
     """
     # find the container by name even if it is stopped already
-    return dockerc.containers(service_names=[VERSION_SERVICE_NAME], stopped=True)[0]
+    return dockerc.compose.ps(services=[VERSION_SERVICE_NAME], all=True)[0]
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the test configuration to use the [python-on-whales] package instead of [pytest-dockerc].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the release of [Cython v3](https://github.com/cython/cython/releases/tag/3.0.0) we now have a dependency issue with our testing configuration. This new version of [Cython] is incompatible with [PyYAML] `5.4.1`, which is the last version of [PyYAML] that the [docker-compose] package will pull. Since the [docker-compose] Python package has been deprecated in favor of the v2 Golang application it is _very_ unlikely ([only maintenance for security fixes](https://github.com/docker/compose/issues/9510#issuecomment-1344054146)) that support for [PyYAML] v6 will be introduced. Due to [build difficulties](https://github.com/yaml/pyyaml/pull/726#issuecomment-1640397938) the odds of a [PyYAML] 5.4.2 which pins under the new [Cython] release is also _very_ unlikely to happen.

This dependency problem coupled with the fact that the last release for the [pytest-dockerc] package was on 2020-10-09 and the latest commit on the default branch of the repository was the same day pushes us to migrate our testing configuration. After some research I settled on the [python-on-whales] package as being most similar in functionality to the [pytest-dockerc] package.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[Cython]: https://github.com/cython/cython
[docker-compose]: https://pypi.org/project/docker-compose/
[pytest-dockerc]: https://gitlab.com/nicofonk/pytest-dockerc
[python-on-whales]: https://github.com/gabrieldemarmiesse/python-on-whales
[PyYAML]: https://github.com/yaml/pyyaml
