### PR TITLE
Modify comment referencing "stopped" parameter

### DIFF
--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -20,7 +20,7 @@ VERSION_FILE = "src/version.txt"
 
 def test_container_count(dockerc):
     """Verify the test composition and container."""
-    # stopped parameter allows non-running containers in results
+    # all parameter allows non-running containers in results
     assert (
         len(dockerc.compose.ps(all=True)) == 2
     ), "Wrong number of containers were started."


### PR DESCRIPTION
## 🗣 Description ##

This pull request edits a comment that references a parameter that no longer exists.

## 💭 Motivation and context ##

The `stopped` parameter is no longer present now that we are using [python-on-whales](https://github.com/gabrieldemarmiesse/python-on-whales).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.