### PR TITLE
Enhance the functionality of the `bump_version.sh` script

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -45,11 +45,10 @@ function update_version {
   git push
 }
 
-old_version=$(sed -n "s/^__version__ = \"\(.*\)\"$/\1/p" $VERSION_FILE)
-
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
   usage
 else
+  old_version=$(sed -n "s/^__version__ = \"\(.*\)\"$/\1/p" $VERSION_FILE)
   case $1 in
     major | minor | patch)
       if [ $# -ne 1 ]; then

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -42,7 +42,6 @@ function update_version {
   mv $tmp_file $README_FILE
   git add $VERSION_FILE $README_FILE
   git commit --message "$3"
-  git push
 }
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-# bump_version.sh (show|major|minor|patch|prerelease|build)
+# Usage:
+#   bump_version.sh (show|major|minor|patch|finalize)
+#   bump_version.sh (build|prerelease) [token]
+# Notes:
+#   - If you specify a token it will only be used if the current version is
+#     tokenless or if the provided token matches the token used in the current
+#     version.
 
 set -o nounset
 set -o errexit
@@ -9,18 +15,33 @@ set -o pipefail
 VERSION_FILE=src/version.txt
 README_FILE=README.md
 
-HELP_INFORMATION="bump_version.sh (show|major|minor|patch|prerelease|build|finalize)"
+function usage {
+  cat << HELP
+Usage:
+  ${0##*/} (show|major|minor|patch|finalize)
+  ${0##*/} (build|prerelease) [token]
+
+Notes:
+  - If you specify a token it will only be used if the current version is
+    tokenless or if the provided token matches the token used in the current
+    version.
+HELP
+  exit 1
+}
 
 old_version=$(sed -n "s/^__version__ = \"\(.*\)\"$/\1/p" $VERSION_FILE)
 # Comment out periods so they are interpreted as periods and don't
 # just match any character
 old_version_regex=${old_version//\./\\\.}
 
-if [ $# -ne 1 ]; then
-  echo "$HELP_INFORMATION"
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  usage
 else
   case $1 in
-    major | minor | patch | prerelease | build)
+    major | minor | patch)
+      if [ $# -ne 1 ]; then
+        usage
+      fi
       new_version=$(python -c "import semver; print(semver.bump_$1('$old_version'))")
       echo Changing version from "$old_version" to "$new_version"
       tmp_file=/tmp/version.$$
@@ -32,7 +53,26 @@ else
       git commit -m"Bump version from $old_version to $new_version"
       git push
       ;;
+    build | prerelease)
+      if [ $# -eq 2 ]; then
+        new_version=$(python -c "import semver; print(semver.bump_$1('$old_version', token='$2'))")
+      else
+        new_version=$(python -c "import semver; print(semver.bump_$1('$old_version'))")
+      fi
+      echo Changing version from "$old_version" to "$new_version"
+      tmp_file=/tmp/version.$$
+      sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
+      mv $tmp_file $VERSION_FILE
+      sed "s/$old_version_regex/$new_version/" $README_FILE > $tmp_file
+      mv $tmp_file $README_FILE
+      git add $VERSION_FILE $README_FILE
+      git commit -m"Bump version from $old_version to $new_version"
+      git push
+      ;;
     finalize)
+      if [ $# -ne 1 ]; then
+        usage
+      fi
       new_version=$(python -c "import semver; print(semver.finalize_version('$old_version'))")
       echo Changing version from "$old_version" to "$new_version"
       tmp_file=/tmp/version.$$
@@ -48,7 +88,7 @@ else
       echo "$old_version"
       ;;
     *)
-      echo "$HELP_INFORMATION"
+      usage
       ;;
   esac
 fi


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds some functionality to the `bump_version.sh` script and DRYs out some of the logic.

> [!Note]
> If/when this pull request is approved I plan on porting the changes over to other skeletons that have a `bump_version.sh` script.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I have used custom tokens for prerelease versions in some of my projects (`dev` instead of `rc` as an example) to better articulate what the version represents. I thought about it and determined that building the functionality into the script would be useful. While I was making the changes to support custom tokens I realized it would also make sense to do some general cleanup of the script.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the script works as expected both with and without custom tokens for `build`/`prerelease` actions. I also verified that other actions worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
