### PR TITLE
Use the full path for source container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=unspecified
 
 # Official Docker images are in the form library/<app> while non-official
 # images are in the form <user>/<app>.
-FROM docker.io/library/python:3.12.0-alpine
+FROM docker.io/library/python:3.12.0-alpine3.18
 
 ARG VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG VERSION=unspecified
 
-FROM python:3.12.0-alpine
+# Official Docker images are in the form library/<app> while non-official
+# images are in the form <user>/<app>.
+FROM docker.io/library/python:3.12.0-alpine
 
 ARG VERSION
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the image used in the `FROM` instruction of the Dockerfile to use the full path for Docker Hub sourced container images. It also updates the tag for the image to specify the version of Alpine Linux.

> [!NOTE]
> I am creating this pull request against a branch that will represent a larger body of work. This branch will later have a pull request against `develop` once the body of work is completed.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Using the full image name will ensure that we pull exactly the image we mean to when building. This is important because some operating systems (such as Red Hat Enterprise Linux) are configured with a default registry other than Docker Hub. It will also make Dockerfile configurations consistent if a non-Docker Hub sourced image is used (such as from a GitHub Container Registry package). Lastly we specify the version of Alpine Linux used to ensure build reproducibility.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
