### PR TITLE
Ensure the `bump-version` script can bump pre-releases

### DIFF
--- a/bump-version
+++ b/bump-version
@@ -125,7 +125,7 @@ if [ -n "$label" ] && [ "$with_prerelease" = false ] && [[ ! " ${commands_with_l
   invalid_option "Setting the label is only allowed for the following commands: ${commands_with_label[*]}"
 fi
 
-if [ "$with_prerelease" = true ] && [[ ! " ${commands_with_prerelease[*]} " =~ [[:space:]]${bump_part}[[:space:]] ]]; then
+if [ "$with_prerelease" = true ] && [ -n "$bump_part" ] && [[ ! " ${commands_with_prerelease[*]} " =~ [[:space:]]${bump_part}[[:space:]] ]]; then
   invalid_option "Changing the prerelease is only allowed in conjunction with the following commands: ${commands_with_prerelease[*]}"
 fi
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This pull request fixes a bug in the logic for checking the `prerelease` command that prevents one from successfully running `./bump-version prerelease`. This resolves #204.

> [!NOTE]
> Upon approval of this pull request I will open an equivalent pull request in [cisagov/skeleton-packer](https://github.com/cisagov/skeleton-packer) since it uses the same version management script.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It is important to be able to bump _just_ the pre-release version.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I also verified that the command checking logic worked as expected:

```console
$ ./bump-version build prerelease
Changing the prerelease is only allowed in conjunction with the following commands: major minor patch
Update the version of the project.

Usage:
  bump-version [--push] [--label LABEL] (major | minor | patch | prerelease | build | finalize | show)
  bump-version --list-files
  bump-version (-h | --help)

Options:
  -h | --help    Show this message.
  --push         Perform a `git push` after updating the version.
  --label LABEL  Specify the label to use when updating the build or prerelease version.
  --list-files   List the files that will be updated when the version is bumped.
$ ./bump-version finalize prerelease
Changing the prerelease is only allowed in conjunction with the following commands: major minor patch
Update the version of the project.

Usage:
  bump-version [--push] [--label LABEL] (major | minor | patch | prerelease | build | finalize | show)
  bump-version --list-files
  bump-version (-h | --help)

Options:
  -h | --help    Show this message.
  --push         Perform a `git push` after updating the version.
  --label LABEL  Specify the label to use when updating the build or prerelease version.
  --list-files   List the files that will be updated when the version is bumped.
$ ./bump-version major prerelease
Changing version from 0.2.0 to 1.0.0
Changing version from 1.0.0 to 1.0.0-rc.1
$ ./bump-version minor prerelease
Changing version from 1.0.0-rc.1 to 1.1.0
Changing version from 1.1.0 to 1.1.0-rc.1
$ ./bump-version patch prerelease
Changing version from 1.1.0-rc.1 to 1.1.1
Changing version from 1.1.1 to 1.1.1-rc.1
$ ./bump-version prerelease
Changing version from 1.1.1-rc.1 to 1.1.1-rc.2
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
