### PR TITLE
Stop using an environment variable to store the list of platforms to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,6 @@ env:
   BUILDX_CACHE_DIR: ~/.cache/buildx
   IMAGE_NAME: cisagov/example
   PIP_CACHE_DIR: ~/.cache/pip
-  PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
-  linux/arm64,linux/ppc64le,linux/s390x"
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
   TERRAFORM_DOCS_REPO_BRANCH_NAME: improvement/support_atx_closed_markdown_headers
@@ -452,12 +450,12 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   build-push-all:
-    # Builds the final set of images for each of the platforms listed in
-    # PLATFORMS environment variable.  These images are tagged with the Docker
-    # tags calculated in the "prepare" job and pushed to Docker Hub and the
-    # GitHub Container Registry.  The contents of README.md are pushed as the
-    # image's description to Docker Hub.  This job is skipped when the
-    # triggering event is a pull request.
+    # Builds the final set of images for each of the platforms specified in the
+    # "platforms" input for the docker/build-push-action Action.  These images
+    # are tagged with the Docker tags calculated in the "prepare" job and
+    # pushed to Docker Hub and the GitHub Container Registry.  The contents of
+    # README.md are pushed as the image's description to Docker Hub.  This job
+    # is skipped when the triggering event is a pull request.
     if: github.event_name != 'pull_request'
     name: Build and push all platforms
     needs:
@@ -541,7 +539,13 @@ jobs:
 
             org.opencontainers.image.version=${{
               needs.prepare.outputs.source_version }}"
-          platforms: ${{ env.PLATFORMS }}
+          platforms: |
+            linux/amd64
+            linux/arm/v6
+            linux/arm/v7
+            linux/arm64
+            linux/ppc64le
+            linux/s390x
           # Uncomment the following option if you are building an image for use
           # on Google Cloud Run or AWS Lambda. The current default image output
           # is unable to run on either. Please see the following issue for more


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the `build` workflow to directly provide the list of target platforms used in the `build-push-all` job directly to the [docker/build-push-action Action] instead of through an environment variable.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The environment variable that is currently used to store platform information is _only_ used in the `build-push-all` job and only for the [docker/build-push-action Action]. Instead of using the more cumbersome CSV format we can instead directly define it in the `platforms` input as a newline delimited list. This will improve the readability of the platforms as well as more directly couple them with where they are used.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the [tag for this branch](https://hub.docker.com/layers/cisagov/example/improvement-stop_storing_platforms_in_environment_variable/images/sha256-de4aa93c6bd3ff1c95402a263a5f55f4b2cfd7caf2d46ab1f540e2d00c2e4f7e) has the expected platforms available.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

[docker/build-push-action Action]: https://github.com/docker/build-push-action
