### PR TITLE
Move the Docker Hub description update to its own job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,8 +503,32 @@ jobs:
           tags: ${{ needs.prepare.outputs.tags }}
           # For a list of pre-defined annotation keys and value types see:
           # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-      - if: ${{ github.ref_name == 'develop' && github.event_name == 'push' }}
-        name: Update the Docker Hub description
+      - name: Setup tmate debug session
+        uses: mxschmitt/action-tmate@v3
+        if: env.RUN_TMATE
+  update-dockerhub:
+    if: ${{ github.ref_name == 'develop' && github.event_name == 'push' }}
+    name: Update the description for the image on Docker Hub
+    needs:
+      - diagnostics
+      - build-push-all
+    permissions:
+      # actions/checkout needs this to fetch code
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          # Uses the organization variable unless overridden
+          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - id: harden-runner
+        name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Update the Docker Hub description
         uses: peter-evans/dockerhub-description@v4
         with:
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -512,6 +536,3 @@ jobs:
           repository: ${{ env.IMAGE_NAME }}
           short-description: ${{ github.event.repository.description }}
           username: ${{ secrets.DOCKER_USERNAME }}
-      - name: Setup tmate debug session
-        uses: mxschmitt/action-tmate@v3
-        if: env.RUN_TMATE


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request moves the step that updates the image's description on Docker Hub into its own job.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is partially because of a bug introduced in #217 when the step that checks out the repository was removed. This resulted in failures because the `README.md` file was no longer present when the step was run. When coming back to fix that bug it made sense to break the step into its own dedicated job to better show when the Docker Hub description is updated in addition to fixing the bug.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I have a good feeling about this.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
