### PR TITLE
Use the repository default branch in the `update-dockerhub` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -522,7 +522,8 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   update-dockerhub:
-    if: ${{ github.ref_name == 'develop' && github.event_name == 'push' }}
+    if: ${{ github.ref_name == github.event.repository.default_branch \
+      && github.event_name == 'push' }}
     name: Update the description for the image on Docker Hub
     needs:
       - diagnostics

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -522,8 +522,9 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
   update-dockerhub:
-    if: ${{ github.ref_name == github.event.repository.default_branch \
-      && github.event_name == 'push' }}
+    if: |
+      github.ref_name == github.event.repository.default_branch
+      && github.event_name == 'push'
     name: Update the description for the image on Docker Hub
     needs:
       - diagnostics


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `if` expression used in the `update-dockerhub` job of the `build` workflow to compare to the default branch of the repository as sourced from the [`github` context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Although we generally use the same default branch it would be good to avoid hard-coded values in general.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified the expected value by pulling the `github` context from a `Run diagnostics` run:

```console
$ jq -r '.event.repository.default_branch' github_context.json
develop
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
