### PR TITLE
Build and push Docker images as separate steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -500,8 +500,41 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push platform images to registries
+      # We only build to ensure that the image layers are cached to push later. This is
+      # because if the build takes over 10 minutes the token acquired to push to the
+      # GitHub Container Registry will have expired. This results in errors like:
+      #
+      # <AuthenticationErrorDetail>Signature not valid in the specified time frame:
+      # Start [Tue, 08 Jul 2025 06:05:02 GMT] - Expiry [Tue, 08 Jul 2025 06:15:07 GMT]
+      # - Current [Tue, 08 Jul 2025 06:16:10 GMT]</AuthenticationErrorDetail>
+      #
+      # Please see https://github.com/docker/build-push-action/issues/1371 for more
+      # information.
+      - name: Build platform images
         id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          # We use the max mode to cache all layers which includes ones from
+          # intermediate steps. This will provide us the potential for more cache hits
+          # and thus better build times. It is also the suggested setting per the
+          # documentation:
+          # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
+          cache-to: type=gha,mode=max
+          labels: ${{ needs.prepare.outputs.labels }}
+          platforms: ${{ join(fromJSON(needs.repo-metadata.outputs.image-platforms)) }}
+          # Uncomment the following option if you are building an image for use
+          # on Google Cloud Run or AWS Lambda. The current default image output
+          # is unable to run on either. Please see the following issue for more
+          # information: https://github.com/docker/buildx/issues/1533
+          # provenance: false
+          tags: ${{ needs.prepare.outputs.tags }}
+          # For a list of pre-defined annotation keys and value types see:
+          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
+      # Now that the image layers should be available from the cache we can push to the
+      # registries.
+      - name: Push platform images to registries
+        id: docker_push
         uses: docker/build-push-action@v6
         with:
           cache-from: type=gha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,6 +342,8 @@ jobs:
           # documentation:
           # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
           cache-to: type=gha,mode=max
+          # For a list of pre-defined annotation keys and value types see:
+          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
           labels: ${{ needs.prepare.outputs.labels }}
           outputs: type=docker,dest=dist/image.tar
           # Uncomment the following option if you are building an image for use
@@ -350,8 +352,6 @@ jobs:
           # information: https://github.com/docker/buildx/issues/1533
           # provenance: false
           tags: ${{ needs.repo-metadata.outputs.image-name }}:latest  # not to be pushed
-          # For a list of pre-defined annotation keys and value types see:
-          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
       - name: Compress image
         run: gzip dist/image.tar
       - name: Upload artifacts
@@ -521,6 +521,8 @@ jobs:
           # documentation:
           # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
           cache-to: type=gha,mode=max
+          # For a list of pre-defined annotation keys and value types see:
+          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
           labels: ${{ needs.prepare.outputs.labels }}
           platforms: ${{ join(fromJSON(needs.repo-metadata.outputs.image-platforms)) }}
           # Uncomment the following option if you are building an image for use
@@ -529,8 +531,6 @@ jobs:
           # information: https://github.com/docker/buildx/issues/1533
           # provenance: false
           tags: ${{ needs.prepare.outputs.tags }}
-          # For a list of pre-defined annotation keys and value types see:
-          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
       # Now that the image layers should be available from the cache we can push to the
       # registries.
       - name: Push platform images to registries
@@ -544,6 +544,8 @@ jobs:
           # documentation:
           # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
           cache-to: type=gha,mode=max
+          # For a list of pre-defined annotation keys and value types see:
+          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
           labels: ${{ needs.prepare.outputs.labels }}
           platforms: ${{ join(fromJSON(needs.repo-metadata.outputs.image-platforms)) }}
           # Uncomment the following option if you are building an image for use
@@ -553,8 +555,6 @@ jobs:
           # provenance: false
           push: true
           tags: ${{ needs.prepare.outputs.tags }}
-          # For a list of pre-defined annotation keys and value types see:
-          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `build-push-all` job of the `build` workflow to push the images as a separate step. It also moves a specific comment block to where it belongs.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I am running into an issue downstream where if a build takes longer than 10 minutes it is unable to push to the GitHub Container Registry due to an expired token. As a workaround we will build the image to cache things and then push once all the layers can be pulled from cache.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I confirmed that the `docker_push` step is using the cached layers.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
