### PR TITLE
Eschew the deprecated `semver.parse_version_info` function

### DIFF
--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -6,7 +6,7 @@ import time
 
 # Third-Party Libraries
 import pytest
-from semver import parse_version_info
+import semver
 
 ENV_VAR = "ECHO_MESSAGE"
 ENV_VAR_VAL = "Hello World from Docker Compose!"
@@ -72,8 +72,8 @@ def test_log_version(dockerc, project_version, version_container):
     """Verify the container outputs the correct version to the logs."""
     # make sure container exited if running test isolated
     dockerc.wait(version_container.id)
-    log_version = parse_version_info(version_container.logs().strip())
-    assert log_version == parse_version_info(
+    log_version = semver.version.Version.parse(version_container.logs().strip())
+    assert log_version == semver.version.Version.parse(
         project_version
     ), f"Container version output to log does not match project version file {VERSION_FILE}"
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request gets rid of the deprecated `semver.parse_version_info` function and modifies the code to instead use `semver.version.Version.parse`.

## 💭 Motivation and context ##

This gets rid of the following warning message when running `pytest`:
> DeprecationWarning: Function 'semver.parse_version_info' is deprecated. Deprecated since version 2.10.0.  This function will be removed in semver 3. Use 'semver.version.Version.parse' instead.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.