### PR TITLE
Upgrade some `actions/checkout` instances to `v6`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,7 +264,7 @@ jobs:
           # monitoring configuration *does not* require you to modify
           # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - id: generate-metadata
         name: Generate Docker image metadata
         uses: docker/metadata-action@v5
@@ -449,7 +449,7 @@ jobs:
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: setup-env
         uses: cisagov/setup-env-github-action@v1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - id: setup-python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/update-dockerhub-description.yml
+++ b/.github/workflows/update-dockerhub-description.yml
@@ -92,7 +92,7 @@ jobs:
           # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Update the Docker Hub description
         uses: peter-evans/dockerhub-description@v5
         with:


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades some instances of `actions/checkout` to `v6`.

## 💭 Motivation and context ##

These were missed when I merged in the upstream changes in cisagov/skeleton-docker#258.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.