### PR TITLE
Add workflow code to generate SBOMs and upload them to the release/pre-release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,8 +38,10 @@ updates:
       - dependency-name: hashicorp/setup-terraform
       - dependency-name: mxschmitt/action-tmate
       # Managed by cisagov/skeleton-docker
+      # - dependency-name: actions/attest-build-provenance
       # - dependency-name: actions/download-artifact
       # - dependency-name: actions/upload-artifact
+      # - dependency-name: anchore/sbom-action
       # - dependency-name: aquasecurity/trivy-action
       # - dependency-name: docker/build-push-action
       # - dependency-name: docker/login-action

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
       - dependency-name: hashicorp/setup-terraform
       - dependency-name: mxschmitt/action-tmate
       # Managed by cisagov/skeleton-docker
-      # - dependency-name: actions/attest-build-provenance
+      # - dependency-name: actions/attest
       # - dependency-name: actions/download-artifact
       # - dependency-name: actions/upload-artifact
       # - dependency-name: anchore/sbom-action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,6 +505,8 @@ jobs:
       - prepare
       - scan
       - test
+    outputs:
+      digest: ${{ steps.docker_push.outputs.digest }}
     permissions:
       # actions/checkout needs this to fetch code
       contents: read
@@ -633,6 +635,7 @@ jobs:
     permissions:
       # Allows us to read the SBOM artifact
       actions: read
+      # Necessary to create the artifact storage record
       artifact-metadata: write
       attestations: write
       # Allows us to add the SBOM to the release
@@ -640,16 +643,15 @@ jobs:
       # Allows the workflow to mint the OIDC token necessary to
       # request a Sigstore signing certificate.
       id-token: write
-    # This line is long, but if I use a block style indicator then GH
-    # Actions doesn't parse and execute the expression.
-    # yamllint disable-line rule:line-length
-    runs-on: ubuntu-${{ startsWith(matrix.architecture, 'arm') && '24.04-arm' || 'latest' }}
+      # Necessary to push the SBOM attestation to ghcr.io
+      packages: write
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        architecture:
-          - amd64
-          - arm64
+        registry:
+          - docker.io
+          - ghcr.io
         sbom-format:
           - cyclonedx-json
           - spdx-json
@@ -699,27 +701,34 @@ jobs:
         with:
           password: ${{ secrets.DOCKER_PASSWORD }}
           username: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
           artifact-name: >-
-            ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
-            matrix.architecture }}.${{ matrix.sbom-format }}
+            ${{ steps.manipulate-repo-name.outputs.repo-name
+            }}.${{ matrix.registry }}.${{ matrix.sbom-format }}
           format: ${{ matrix.sbom-format }}
           image: >-
-            docker.io/${{ needs.repo-metadata.outputs.image-name
+            ${{ matrix.registry }}/${{ needs.repo-metadata.outputs.image-name
             }}:${{ steps.dockerize-ref-name.outputs.ref }}
-          platform: linux/${{ matrix.architecture }}
           output-file: >-
-            ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
-            matrix.architecture }}.${{ matrix.sbom-format }}
-      - name: Create SBOM attestation
+            ${{ steps.manipulate-repo-name.outputs.repo-name
+            }}.${{ matrix.registry }}.${{ matrix.sbom-format }}
+      - name: Create SBOM attestation for Docker image
         uses: actions/attest@v4
         with:
           push-to-registry: true
           sbom-path: >-
-            ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
-            matrix.architecture }}.${{ matrix.sbom-format }}
+            ${{ steps.manipulate-repo-name.outputs.repo-name
+            }}.${{ matrix.registry }}.${{ matrix.sbom-format }}
+          subject-digest: >-
+            ${{ needs.build-push-all.outputs.digest }}
           subject-name: >-
-            docker.io/${{ needs.repo-metadata.outputs.image-name
-            }}:${{ steps.dockerize-ref-name.outputs.ref }}
+            ${{ matrix.registry
+            }}/${{ needs.repo-metadata.outputs.image-name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -684,16 +684,29 @@ jobs:
           | tr '[:upper:]' '[:lower:]' \
           | tr '/' '-')
           echo "ref=${DOCKERIZED_REF}" >> $GITHUB_OUTPUT
-      - name: Gemerate SBOM
+      - name: Manipulate the repo name into the preferred format
+        id: manipulate-repo-name
+        run: |
+          NEW_NAME=$(echo "${{ github.repository}}" \
+          | tr '[:upper:]' '[:lower:]' \
+          | tr '/ ' '-')
+          echo "repo-name=${NEW_NAME}" >> $GITHUB_OUTPUT
+      - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          artifact-name: sbom.${{ matrix.architecture }}.${{ matrix.sbom-format }}
+          artifact-name: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
+            matrix.architecture }}.${{ matrix.sbom-format }}
           format: ${{ matrix.sbom-format }}
           image: >-
             ${{ needs.repo-metadata.outputs.image-name
             }}:${{ steps.dockerize-ref-name.outputs.ref }}
-          output-file: sbom.${{ matrix.architecture }}.${{ matrix.sbom-format }}
+          output-file: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
+            matrix.architecture }}.${{ matrix.sbom-format }}
       - name: Attest build provenance for the SBOM
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: sbom.${{ matrix.architecture }}.${{ matrix.sbom-format }}
+          subject-path: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
+            matrix.architecture }}.${{ matrix.sbom-format }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,7 +373,7 @@ jobs:
       - name: Create provenance attestation for artifacts
         uses: actions/attest@v4
         with:
-          subject-path: dist
+          subject-path: image.tar.gz
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -612,3 +612,82 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
+  generate-sbom:
+    # Generate an SBOM for the Docker image and, if there is a
+    # release, upload it as an asset to the release.
+    #
+    # This job is located in this workflow as opposed to a separate
+    # release workflow because it can only run after the
+    # build-push-all job.  Putting it in a separate workflow would
+    # require us to introduce a dependency of the release workflow on
+    # this one.
+    if: github.event_name != 'pull_request'
+    name: Generate and upload SBOM
+    needs:
+      - diagnostics
+      - repo-metadata
+      - build-push-all
+    permissions:
+      # Allows us to read the SBOM artifact
+      actions: read
+      artifact-metadata: write
+      attestations: write
+      # Allows us to add the SBOM to the release
+      contents: write
+      # Allows the workflow to mint the OIDC token necessary to
+      # request a Sigstore signing certificate.
+      id-token: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sbom-format:
+          - cyclonedx-json
+          - spdx-json
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-docker#224 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - name: Manipulate the ref name into the format that Docker prefers
+        id: dockerize-ref-name
+        run: |
+          DOCKERIZED_REF=$(echo "${{ github.ref_name}}" \
+          | tr '[:upper:]' '[:lower:]' \
+          | tr '/' '-')
+          echo "ref=${DOCKERIZED_REF}" >> $GITHUB_OUTPUT
+      - name: Gemerate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          artifact-name: sbom.${{ matrix.sbom-format }}
+          format: ${{ matrix.sbom-format }}
+          image: >-
+            ${{ needs.repo-metadata.outputs.image-name
+            }}:${{ steps.dockerize-ref-name.outputs.ref }}
+          output-file: sbom.${{ matrix.sbom-format }}
+      - name: Attest build provenance for the SBOM
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: sbom.${{ matrix.sbom-format }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,8 +302,16 @@ jobs:
       - repo-metadata
       - prepare
     permissions:
-      # actions/checkout needs this to fetch code
-      contents: read
+      # Allows us to read the artifacts
+      actions: read
+      # Necessary to create the artifact storage record
+      artifact-metadata: write
+      attestations: write
+      # Allows us to add artifacts to the release.
+      contents: write
+      # Allows the workflow to mint the OIDC token necessary to
+      # request a Sigstore signing certificate.
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Apply standard cisagov job preamble
@@ -364,6 +372,10 @@ jobs:
         with:
           archive: false
           path: image.tar.gz
+      - name: Create provenance attestation for artifacts
+        uses: actions/attest@v4
+        with:
+          subject-path: dist
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -704,6 +704,7 @@ jobs:
           image: >-
             ${{ needs.repo-metadata.outputs.image-name
             }}:${{ steps.dockerize-ref-name.outputs.ref }}
+          platform: linux/${{ matrix.architecture }}
           output-file: >-
             ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
             matrix.architecture }}.${{ matrix.sbom-format }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -624,9 +624,9 @@ jobs:
     if: github.event_name != 'pull_request'
     name: Generate and upload SBOM
     needs:
+      - build-push-all
       - diagnostics
       - repo-metadata
-      - build-push-all
     permissions:
       # Allows us to read the SBOM artifact
       actions: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -720,6 +720,12 @@ jobs:
           output-file: >-
             ${{ steps.manipulate-repo-name.outputs.repo-name
             }}.${{ matrix.registry }}.${{ matrix.sbom-format }}
+      - name: Create provenance attestation for SBOM
+        uses: actions/attest@v4
+        with:
+          subject-path: >-
+            ${{ steps.manipulate-repo-name.outputs.repo-name
+            }}.${{ matrix.registry }}.${{ matrix.sbom-format }}
       - name: Create SBOM attestation for Docker image
         uses: actions/attest@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -621,6 +621,9 @@ jobs:
     # build-push-all job.  Putting it in a separate workflow would
     # require us to introduce a dependency of the release workflow on
     # this one.
+    #
+    # This if statement is present to keep the push and pull_request
+    # events from both causing the job to be run.
     if: github.event_name != 'pull_request'
     name: Generate and upload SBOM
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,13 +302,11 @@ jobs:
       - repo-metadata
       - prepare
     permissions:
-      # Allows us to read the artifacts
-      actions: read
       # Necessary to create the artifact storage record
       artifact-metadata: write
       attestations: write
-      # Allows us to add artifacts to the release.
-      contents: write
+      # Allows read access to repository contents (e.g., for checkout).
+      contents: read
       # Allows the workflow to mint the OIDC token necessary to
       # request a Sigstore signing certificate.
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -707,7 +707,7 @@ jobs:
             matrix.architecture }}.${{ matrix.sbom-format }}
           format: ${{ matrix.sbom-format }}
           image: >-
-            ${{ needs.repo-metadata.outputs.image-name
+            docker.io/${{ needs.repo-metadata.outputs.image-name
             }}:${{ steps.dockerize-ref-name.outputs.ref }}
           platform: linux/${{ matrix.architecture }}
           output-file: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -694,6 +694,11 @@ jobs:
           | tr '[:upper:]' '[:lower:]' \
           | tr '/ ' '-')
           echo "repo-name=${NEW_NAME}" >> $GITHUB_OUTPUT
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -637,10 +637,16 @@ jobs:
       # Allows the workflow to mint the OIDC token necessary to
       # request a Sigstore signing certificate.
       id-token: write
-    runs-on: ubuntu-latest
+    # This line is long, but if I use a block style indicator then GH
+    # Actions doesn't parse and execute the expression.
+    # yamllint disable-line rule:line-length
+    runs-on: ubuntu-${{ startsWith(matrix.architecture, 'arm') && '24.04-arm' || 'latest' }}
     strategy:
       fail-fast: false
       matrix:
+        architecture:
+          - amd64
+          - arm64
         sbom-format:
           - cyclonedx-json
           - spdx-json
@@ -681,13 +687,13 @@ jobs:
       - name: Gemerate SBOM
         uses: anchore/sbom-action@v0
         with:
-          artifact-name: sbom.${{ matrix.sbom-format }}
+          artifact-name: sbom.${{ matrix.architecture }}.${{ matrix.sbom-format }}
           format: ${{ matrix.sbom-format }}
           image: >-
             ${{ needs.repo-metadata.outputs.image-name
             }}:${{ steps.dockerize-ref-name.outputs.ref }}
-          output-file: sbom.${{ matrix.sbom-format }}
+          output-file: sbom.${{ matrix.architecture }}.${{ matrix.sbom-format }}
       - name: Attest build provenance for the SBOM
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: sbom.${{ matrix.sbom-format }}
+          subject-path: sbom.${{ matrix.architecture }}.${{ matrix.sbom-format }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -713,9 +713,13 @@ jobs:
           output-file: >-
             ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
             matrix.architecture }}.${{ matrix.sbom-format }}
-      - name: Attest build provenance for the SBOM
-        uses: actions/attest-build-provenance@v3
+      - name: Create SBOM attestation
+        uses: actions/attest@v4
         with:
-          subject-path: >-
+          push-to-registry: true
+          sbom-path: >-
             ${{ steps.manipulate-repo-name.outputs.repo-name }}.${{
             matrix.architecture }}.${{ matrix.sbom-format }}
+          subject-name: >-
+            docker.io/${{ needs.repo-metadata.outputs.image-name
+            }}:${{ steps.dockerize-ref-name.outputs.ref }}


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds workflow code to generate SBOMs for the Docker images
- If we happen to be building a release or pre-release then the SBOMs will be uploaded to the release or pre-release.
- Adds workflow code to create provenance attestations for the SBOMs and the Docker image artifact
- Adds workflow code to create SBOM attestations for the Docker images

## 💭 Motivation and context ##

CISA advocates for the use of SBOMs, so we should be generating them for our software products.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Mark SBOM checks as required.