### PR TITLE
Specify artifact name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,6 +363,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           archive: false
+          name: image.tar.gz
           path: image.tar.gz
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates `build.yml` to specify the artifact name when uploading via [actions/upload-artifact](https://github.com/actions/upload-artifact).

## 💭 Motivation and context ##

Otherwise the artifact will be uploaded with the default name of `artifact`.

See the [`actions/upload-artifact` documentation](https://github.com/actions/upload-artifact?tab=readme-ov-file#inputs) for more details.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.