### PR TITLE
Move package versions out of the Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,9 @@ updates:
       interval: weekly
 
   - directory: /
+    exclude-paths:
+      # Allow updates for dependencies here to be handled separately.
+      - src/**
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,8 +18,7 @@ dependencies:
           # Add any dependency files used.
           - "**/Pipfile*"
           - .pre-commit-config.yaml
-          - requirements*.txt
-          - src/requirements-actually-constraints.txt
+          - "**/requirements*.txt"
 docker:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,7 @@ dependencies:
           - "**/Pipfile*"
           - .pre-commit-config.yaml
           - requirements*.txt
+          - src/requirements-actually-constraints.txt
 docker:
   - changed-files:
       - any-glob-to-any-file:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG CISA_USER="cisa"
 ENV CISA_HOME="/home/${CISA_USER}"
 ENV VIRTUAL_ENV="${CISA_HOME}/.venv"
 
+# Work out of /tmp for this stage
+WORKDIR /tmp
+
 # Copy in the pip constraints file that controls the versions installed below
 COPY src/requirements-actually-constraints.txt ./constraints.txt
 
@@ -47,7 +50,6 @@ RUN python3 -m pip install --no-cache-dir --upgrade \
 # Note that pipenv will install into a virtual environment if the VIRTUAL_ENV
 # environment variable is set.
 ###
-WORKDIR /tmp
 COPY src/Pipfile src/Pipfile.lock ./
 RUN pipenv install --clear --deploy --extra-pip-args "--no-cache-dir" --verbose
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,32 +9,37 @@ ARG CISA_USER="cisa"
 ENV CISA_HOME="/home/${CISA_USER}"
 ENV VIRTUAL_ENV="${CISA_HOME}/.venv"
 
-# Versions of the Python packages installed directly
-ENV PYTHON_PIP_VERSION=26.0.1
-ENV PYTHON_PIPENV_VERSION=2026.0.3
-ENV PYTHON_SETUPTOOLS_VERSION=82.0.0
+# Copy in the pip constraints file that controls the versions installed below
+COPY src/requirements-actually-constraints.txt ./constraints.txt
 
 ###
-# Install the specified versions of pip and setuptools into the system
-# Python environment; install the specified version of pipenv into the system Python
-# environment; set up a Python virtual environment (venv); and install the specified
-# versions of pip and setuptools into the venv.
+# Install pip and setuptools into the system Python environment, install
+# pipenv into the system Python environment, set up a Python virtual
+# environment (venv), and install pip and setuptools into the venv.
 #
 # Note that we use the --no-cache-dir flag to avoid writing to a local
 # cache.  This results in a smaller final image, at the cost of
 # slightly longer install times.
+#
+# Note that we use the --constraint flag to specify a pip constraints
+# file that controls which package versions are installed. Please see
+# the documentation for more information:
+# https://pip.pypa.io/en/stable/user_guide/#constraints-files
 ###
 RUN python3 -m pip install --no-cache-dir --upgrade \
-        pip==${PYTHON_PIP_VERSION} \
-        setuptools==${PYTHON_SETUPTOOLS_VERSION} \
+      --constraint constraints.txt \
+      pip \
+      setuptools \
     && python3 -m pip install --no-cache-dir --upgrade \
-        pipenv==${PYTHON_PIPENV_VERSION} \
+      --constraint constraints.txt \
+      pipenv \
     # Manually create the virtual environment
     && python3 -m venv ${VIRTUAL_ENV} \
     # Ensure the core Python packages are installed in the virtual environment
     && ${VIRTUAL_ENV}/bin/python3 -m pip install --no-cache-dir --upgrade \
-        pip==${PYTHON_PIP_VERSION} \
-        setuptools==${PYTHON_SETUPTOOLS_VERSION}
+        --constraint constraints.txt \
+        pip \
+        setuptools
 
 ###
 # Install the Python dependencies into the virtual environment.

--- a/src/requirements-actually-constraints.txt
+++ b/src/requirements-actually-constraints.txt
@@ -1,0 +1,11 @@
+###
+# This is a pip constraints file:
+# https://pip.pypa.io/en/stable/user_guide/#constraints-files
+#
+# Note on the file's name:
+# Since dependabot does not support updating pip constraints files we have to trick
+# it into seeing the file as a pip requirements file to get automatic updates.
+###
+pip==26.0.1
+pipenv==2026.0.3
+setuptools==82.0.0


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request moves versioning of the Python packages we install in the Dockerfile to set up a Python venv out of the Dockerfile. The package version constraints are moved into a separate [pip constraints file](https://pip.pypa.io/en/stable/user_guide/#constraints-files) that is copied in and used during package installation.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Currently we have to manually update the versions of `pip`, `pipenv`, and `setuptools` that are installed in the venv setup. This change should allow us to get dependabot automatic updates for these packages now.

> [!NOTE]
> The constraints file uses the name it does to trick dependabot into offering updates to the packages it lists. This is necessary because dependabot does not work with pip constraints files at this time.

> [!NOTE]
> Since I am not changing the versions of the packages used I do not see a reason to bump the version of the image.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this locally and it built without issue. Waiting for the `pip-audit` hook fix to trickle down before automated tests will pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
