### PR TITLE
Only allow Dependabot to update the lockfile in `src`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,7 @@ updates:
     package-ecosystem: pip
     schedule:
       interval: weekly
-    versioning-strategy: lockfile-only
+    versioning-strategy: increase-if-necessary
 
   - directory: /
     package-ecosystem: terraform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,12 @@ updates:
     schedule:
       interval: weekly
 
+  - directory: /src
+    package-ecosystem: pip
+    schedule:
+      interval: weekly
+    versioning-strategy: lockfile-only
+
   - directory: /
     package-ecosystem: terraform
     schedule:


### PR DESCRIPTION
## 🗣 Description ##

This pull request sets the [versioning strategy](https://docs.github.com/en/enterprise-cloud@latest/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--) in the Dependabot configuration so that it is only allowed to update `Pipfile.lock` in `src`; `Pipfile` will not be altered.

## 💭 Motivation and context ##

This should fix PRs like cisagov/code-gov-update#311, where previously Dependabot wanted to incorrectly force the new version as a constraint into the `Pipfile`.

## 🧪 Testing ##

All automated tests pass.  The real test would be when Dependabot runs after this PR is merged.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.