### PR TITLE
Add a new job to the `build` workflow that test builds each platform individually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -501,9 +501,6 @@ jobs:
     permissions:
       # actions/checkout needs this to fetch code
       contents: read
-      # When Dependabot creates a PR it requires this permission in
-      # order to push Docker images to ghcr.io.
-      packages: write
     runs-on: ubuntu-latest
     strategy:
       # We want each platform to build regardless of failures on other platforms

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -489,6 +489,83 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v3
         if: env.RUN_TMATE
+  test-build-each-platform:
+    name: Test build the ${{ matrix.platform }} image
+    needs:
+      - diagnostics
+      - lint
+      - repo-metadata
+      - prepare
+      - scan
+      - test
+    permissions:
+      # actions/checkout needs this to fetch code
+      contents: read
+      # When Dependabot creates a PR it requires this permission in
+      # order to push Docker images to ghcr.io.
+      packages: write
+    runs-on: ubuntu-latest
+    strategy:
+      # We want each platform to build regardless of failures on other platforms
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(needs.repo-metadata.outputs.image-platforms) }}
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-docker#224 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build a platform's image
+        id: docker_build
+        uses: docker/build-push-action@v7
+        with:
+          cache-from: type=gha
+          # We use the max mode to cache all layers which includes ones from
+          # intermediate steps. This will provide us the potential for more cache hits
+          # and thus better build times. It is also the suggested setting per the
+          # documentation:
+          # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
+          cache-to: type=gha,mode=max
+          # For a list of pre-defined annotation keys and value types see:
+          # https://github.com/opencontainers/image-spec/blob/master/annotations.md
+          labels: ${{ needs.prepare.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          # Ensure we do not push the image to the registry as this is only a test build
+          push: false
+      - name: Setup tmate debug session
+        uses: mxschmitt/action-tmate@v3
+        if: env.RUN_TMATE
   build-push-all:
     # Builds the final set of images for each of the platforms specified in the
     # "platforms" input for the docker/build-push-action Action.  These images
@@ -505,6 +582,7 @@ jobs:
       - prepare
       - scan
       - test
+      - test-build-each-platform
     permissions:
       # actions/checkout needs this to fetch code
       contents: read


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a new `test-build-each-platform` job to the `build` workflow that will test build each of the supported platforms in parallel. This new job is also added as a requirement for the `build-push-all` job.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I have previously had issues where a specific platform's build fails and reading through the Docker build log in the GitHub Actions log can be tedious. I thought it would help to perform a test build for each supported platform to better isolate build issues. Since we use GitHub Actions as our Docker cache backend this would also hopefully pre-seed the cache for the eventual `build-push-all` job.

> [!NOTE]
> In the `build-push-all` job we currently use the [docker/build-push-action](https://github.com/docker/build-push-action) action twice; once to build all of the platforms to load the cache and a second time to pull the cache layers and push the completed multi-platform image. We _may_ be able to discard this two-run approach if the test build jobs can fulfill the same purpose as the initial image build in our current configuration. We will likely want to test that this works as expected separately.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
